### PR TITLE
Update remove_unused.ex

### DIFF
--- a/lib/mix/tasks/remove_unused.ex
+++ b/lib/mix/tasks/remove_unused.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.RemoveUnused do
     File.stream!(file_path)
     |> Stream.with_index(1)
     |> Stream.map(fn {line, i} ->
-      if i in line_numbers do
+      if i in Enum.map(line_numbers, fn n -> elem(n, 0) end) do
         ""
       else
         line


### PR DESCRIPTION
Enum.map(line_numbers, fn n -> elem(n, 0) end) instead of line_numbers

Tested in Elixir 1.16